### PR TITLE
Add server path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ This training loop runs until a specified number of inference and training itera
 
 ART should work with most vLLM/HuggingFace-transformers compatible causal language models, or at least the ones supported by [Unsloth](https://docs.unsloth.ai/get-started/all-our-models). Gemma 3 does not appear to be supported for the time being. If any other model isn't working for you, please let us know on [Discord](https://discord.gg/zbBHRUpwf4) or open an issue on [GitHub](https://github.com/openpipe/art/issues)!
 
+## Remote Server Usage
+
+When launching a remote server with `art run`, you can specify `--path` to control where the server stores model weights and training artifacts. This is helpful if you need the data on a particular volume or want to keep multiple projects separate.
+
+```bash
+art run --path /data/art
+```
+
 ## 🤝 Contributing
 
 ART is in active development, and contributions are most welcome! Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file for more information.

--- a/examples/remote_backend/README.md
+++ b/examples/remote_backend/README.md
@@ -1,0 +1,9 @@
+# Remote Backend Example
+
+Start the ART server on a remote machine and specify where model weights and artifacts should be stored:
+
+```bash
+art run --path /mnt/art_storage
+```
+
+Then point your client at the server by setting `OPENPIPE_API_BASE` to its URL.

--- a/src/art/cli.py
+++ b/src/art/cli.py
@@ -18,7 +18,15 @@ app = typer.Typer()
 
 
 @app.command()
-def run(host: str = "0.0.0.0", port: int = 7999) -> None:
+def run(
+    host: str = "0.0.0.0",
+    port: int = 7999,
+    path: str | None = typer.Option(
+        None,
+        "--path",
+        help="Directory for model weights and artifacts",
+    ),
+) -> None:
     """Run the ART CLI."""
 
     # check if port is available
@@ -42,7 +50,7 @@ def run(host: str = "0.0.0.0", port: int = 7999) -> None:
     TrajectoryGroup.__new__ = __new__  # type: ignore
     TrajectoryGroup.__init__ = __init__
 
-    backend = LocalBackend()
+    backend = LocalBackend(path=path)
     app = FastAPI()
     app.get("/healthcheck")(lambda: {"status": "ok"})
     app.post("/close")(backend.close)


### PR DESCRIPTION
## Summary
- allow `--path` in `art run` to set backend directory
- document new flag in README
- add remote backend example with `--path`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848638ae8908327823cc7f0d8197019