### PR TITLE
Add temperature annealer feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,41 @@ ART's functionality is divided into a **client** and a **server**. The OpenAI-co
 
 This training loop runs until a specified number of inference and training iterations have completed.
 
+## 🛰 Remote Server Usage
+
+ART's server can run on any machine with a GPU. Start it on the remote host:
+
+```bash
+uv run art --host 0.0.0.0 --port 7999
+```
+
+From your local machine, create a `Backend` that points at this server and
+register your model with it:
+
+```python
+backend = art.Backend(base_url="http://<server-ip>:7999")
+await model.register(backend)
+```
+
+`model.openai_client()` will now send completions to the remote server and all
+calls to `model.train()` execute there as well. See
+`examples/remote_backend/remote_2048.py` for a full example.
+
+## 🔥 Temperature Annealing
+
+You can linearly anneal the sampling temperature between training calls. Create
+a `LinearTemperatureAnnealer` and attach it to your `TrainableModel`:
+
+```python
+annealer = art.LinearTemperatureAnnealer(start=1.0, end=0.1, steps=10)
+model.set_temperature_annealer(annealer)
+```
+
+Each call to `model.train()` will advance the schedule and restart the
+OpenAI-compatible server with the new default temperature. Explicit temperatures
+passed to `model.openai_client().chat.completions.create()` still override the
+current default.
+
 ## 🧩 Supported Models
 
 ART should work with most vLLM/HuggingFace-transformers compatible causal language models, or at least the ones supported by [Unsloth](https://docs.unsloth.ai/get-started/all-our-models). Gemma 3 does not appear to be supported for the time being. If any other model isn't working for you, please let us know on [Discord](https://discord.gg/zbBHRUpwf4) or open an issue on [GitHub](https://github.com/openpipe/art/issues)!

--- a/examples/remote_backend/README.md
+++ b/examples/remote_backend/README.md
@@ -1,0 +1,22 @@
+# Remote Backend Example
+
+This example demonstrates how to connect to an ART server running on a
+remote machine. The training loop is the same as in the local examples,
+but all inference and training happen on the remote server.
+
+1. Start the ART server on a machine with a GPU:
+
+```bash
+uv run art --host 0.0.0.0 --port 7999
+```
+
+2. On your local machine, set `ART_SERVER_URL` to the server's address and
+run `remote_2048.py`:
+
+```bash
+ART_SERVER_URL=http://<server-ip>:7999 python remote_2048.py
+```
+
+The script will register the model with the remote server, gather
+trajectories, and train the model remotely while you drive the loop
+locally.

--- a/examples/remote_backend/remote_2048.py
+++ b/examples/remote_backend/remote_2048.py
@@ -1,0 +1,64 @@
+import asyncio
+import os
+import random
+import sys
+from dotenv import load_dotenv
+
+# Add the 2048 example directory to the path so we can reuse its rollout
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "2048"))
+from rollout import rollout  # type: ignore
+
+import art
+
+load_dotenv()
+random.seed(42)
+
+# URL of the remote ART server (e.g. "http://123.45.67.89:7999")
+REMOTE_URL = os.getenv("ART_SERVER_URL", "http://localhost:7999")
+backend = art.Backend(base_url=REMOTE_URL)
+
+# Declare a trainable model. Its weights and training will live on the server.
+model = art.TrainableModel(
+    name="remote-2048",
+    project="2048-remote",
+    base_model="Qwen/Qwen2.5-7B-Instruct",
+)
+model._internal_config = art.dev.InternalModelConfig(
+    init_args=art.dev.InitArgs(max_seq_length=8192),
+    engine_args=art.dev.EngineArgs(
+        enforce_eager=True,
+        gpu_memory_utilization=0.8,
+        num_scheduler_steps=1,
+    ),
+)
+model.set_temperature_annealer(
+    art.LinearTemperatureAnnealer(start=1.0, end=0.1, steps=5)
+)
+
+
+async def main() -> None:
+    # Register the model with the remote backend. This also starts the
+    # OpenAI-compatible inference server on the remote machine.
+    await model.register(backend)
+
+    for i in range(await model.get_step(), 5):
+        train_groups = await art.gather_trajectory_groups(
+            (
+                art.TrajectoryGroup(
+                    rollout(model, i, is_validation=False) for _ in range(18)
+                )
+                for _ in range(1)
+            ),
+            pbar_desc="gather",
+            max_exceptions=18,
+        )
+        await model.delete_checkpoints()
+        await model.train(
+            train_groups,
+            config=art.TrainConfig(learning_rate=3e-5),
+            _config={"logprob_calculation_chunk_size": 8},
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/art/__init__.py
+++ b/src/art/__init__.py
@@ -15,6 +15,7 @@ from .backend import Backend
 from .gather import gather_trajectories, gather_trajectory_groups
 from .model import Model, TrainableModel
 from .trajectories import Trajectory, TrajectoryGroup
+from .temperature import LinearTemperatureAnnealer
 from .types import Messages, MessagesAndChoices, Tools, TrainConfig
 from .utils import retry
 
@@ -32,4 +33,5 @@ __all__ = [
     "TrainConfig",
     "Trajectory",
     "TrajectoryGroup",
+    "LinearTemperatureAnnealer",
 ]

--- a/src/art/backend.py
+++ b/src/art/backend.py
@@ -49,6 +49,15 @@ class Backend:
         response.raise_for_status()
         return response.json()
 
+    async def _set_temperature(
+        self, model: "TrainableModel", temperature: float
+    ) -> None:
+        response = await self._client.post(
+            "/_set_temperature",
+            json={"model": model.model_dump(), "temperature": temperature},
+        )
+        response.raise_for_status()
+
     async def _delete_checkpoints(
         self,
         model: "TrainableModel",

--- a/src/art/cli.py
+++ b/src/art/cli.py
@@ -50,6 +50,12 @@ def run(host: str = "0.0.0.0", port: int = 7999) -> None:
     app.post("/_get_step")(backend._get_step)
     app.post("/_delete_checkpoints")(backend._delete_checkpoints)
 
+    @app.post("/_set_temperature")
+    async def _set_temperature(
+        model: TrainableModel = Body(...), temperature: float = Body(...)
+    ) -> None:
+        await backend._set_temperature(model, temperature)
+
     @app.post("/_prepare_backend_for_training")
     async def _prepare_backend_for_training(
         model: TrainableModel,

--- a/src/art/local/backend.py
+++ b/src/art/local/backend.py
@@ -184,6 +184,12 @@ class LocalBackend(Backend):
     def __get_step(self, model: TrainableModel) -> int:
         return get_step(get_model_dir(model=model, art_path=self._path))
 
+    async def _set_temperature(
+        self, model: TrainableModel, temperature: float
+    ) -> None:
+        service = await self._get_service(model)
+        await service.set_temperature(temperature)
+
     async def _delete_checkpoints(
         self,
         model: TrainableModel,

--- a/src/art/local/service.py
+++ b/src/art/local/service.py
@@ -168,3 +168,15 @@ class ModelService:
         lora_request.lora_path = lora_path
         self.state.vllm.async_engine.engine.remove_lora(1)
         self.state.vllm.async_engine.engine.add_lora(lora_request)  # type: ignore
+
+    async def set_temperature(self, temperature: float) -> None:
+        self.config.setdefault("trainer_args", {})["temperature"] = temperature
+        self.state.trainer.args.temperature = temperature  # type: ignore
+        await self.start_openai_server(
+            dev.OpenAIServerConfig(
+                engine_args=dev.EngineArgs(
+                    override_generation_config={"temperature": temperature}
+                )
+            )
+        )
+

--- a/src/art/model.py
+++ b/src/art/model.py
@@ -5,6 +5,7 @@ from . import dev
 from .backend import Backend
 from .openai import patch_openai
 from .trajectories import Trajectory, TrajectoryGroup
+from .temperature import LinearTemperatureAnnealer
 from .types import TrainConfig
 from pydantic import BaseModel
 from openai import (
@@ -167,6 +168,7 @@ class TrainableModel(Model):
     # The fields within `_internal_config` are unstable and subject to change.
     # Use at your own risk.
     _internal_config: dev.InternalModelConfig | None = None
+    _temperature_annealer: LinearTemperatureAnnealer | None = None
 
     def __init__(self, **data):
         # Pop any internal config provided at construction and assign it
@@ -180,6 +182,12 @@ class TrainableModel(Model):
         data = super().model_dump(*args, **kwargs)
         data["_internal_config"] = self._internal_config
         return data
+
+    def set_temperature_annealer(
+        self, annealer: LinearTemperatureAnnealer | None
+    ) -> None:
+        """Attach a temperature annealer to this model."""
+        object.__setattr__(self, "_temperature_annealer", annealer)
 
     async def register(
         self,
@@ -233,6 +241,9 @@ class TrainableModel(Model):
             _config: Additional configuration that is subject to change and
                 not yet part of the public API. Use at your own risk.
         """
+        if self._temperature_annealer is not None:
+            temp = self._temperature_annealer.step()
+            await self.backend()._set_temperature(self, temp)
         async for _ in self.backend()._train_model(
             self, list(trajectory_groups), config, _config or {}, verbose
         ):

--- a/src/art/temperature.py
+++ b/src/art/temperature.py
@@ -1,0 +1,16 @@
+class LinearTemperatureAnnealer:
+    """Linearly anneals between two temperature values."""
+
+    def __init__(self, *, start: float, end: float, steps: int) -> None:
+        self.start = start
+        self.end = end
+        self.steps = max(1, steps)
+        self._step = 0
+
+    def step(self) -> float:
+        """Advance the schedule and return the new temperature."""
+        fraction = min(self._step / (self.steps - 1), 1.0)
+        temperature = self.start + (self.end - self.start) * fraction
+        self._step += 1
+        return temperature
+


### PR DESCRIPTION
## Summary
- document how to start a remote server and use temperature annealing
- expose `LinearTemperatureAnnealer` in the library
- restart the OpenAI server with an updated temperature between training rounds
- add example of annealing in `remote_backend/remote_2048.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684851a680b48327ba898209a0e86e7d