### PR TITLE
Add temperature annealing support to torchtune backend

### DIFF
--- a/src/art/torchtune/service.py
+++ b/src/art/torchtune/service.py
@@ -123,6 +123,20 @@ class TorchtuneService:
             # remove the weights file
             Path(weights_path).unlink(missing_ok=True)
 
+    async def set_temperature(self, temperature: float) -> None:
+        self.config.setdefault("trainer_args", {})["temperature"] = temperature
+        override_generation_config = self.config.setdefault(
+            "engine_args", {}
+        ).setdefault("override_generation_config", {})
+        override_generation_config["temperature"] = temperature
+        await self.start_openai_server(
+            dev.OpenAIServerConfig(
+                engine_args=dev.EngineArgs(
+                    override_generation_config={"temperature": temperature}
+                )
+            )
+        )
+
     async def update_worker_weights(
         self, llm: AsyncLLM, weights_path: str, profile: bool
     ) -> None:


### PR DESCRIPTION
## Summary
- implement `set_temperature` on the torchtune model service so annealing updates restart the OpenAI server with the new sampling temperature

## Testing
- ./scripts/run_checks.sh *(fails: existing formatting, lint, type-checking, and pytest issues; command interrupted during uv.lock check after extended hang)*
- uv run ruff format src/art/torchtune/service.py
- uv run ruff check src/art/torchtune/service.py

------
https://chatgpt.com/codex/tasks/task_e_68dae203c7f483278452a178729b00f6